### PR TITLE
fixed issue throwing exception when getting new room.

### DIFF
--- a/src/HipChat.Net/HipChat.Net.nuspec
+++ b/src/HipChat.Net/HipChat.Net.nuspec
@@ -11,7 +11,7 @@
     <iconUrl>https://raw.githubusercontent.com/sirkirby/hipchat.net/master/pkglogo.png</iconUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>HipChat API v2 portable client library for .NET. Issue? https://github.com/sirkirby/hipchat.net/issues</description>
-    <releaseNotes>initial release</releaseNotes>
+    <releaseNotes>Fixed issue throwing exception when getting new room.</releaseNotes>
     <copyright>Copyright Chris Kirby 2014</copyright>
     <tags>hipchat chat api</tags>
   </metadata>

--- a/src/HipChat.Net/Models/Response/Room.cs
+++ b/src/HipChat.Net/Models/Response/Room.cs
@@ -10,7 +10,7 @@ namespace HipChat.Net.Models.Response
     public string JabberId { get; set; }
 
     [JsonProperty("last_active")]
-    public DateTime LastActive { get; set; }
+    public Nullable<DateTime> LastActive { get; set; }
 
     [JsonProperty("created")]
     public DateTime Created { get; set; }

--- a/src/HipChat.Net/Properties/AssemblyInfo.cs
+++ b/src/HipChat.Net/Properties/AssemblyInfo.cs
@@ -24,6 +24,6 @@ using System.Reflection;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.1.1")]
-[assembly: AssemblyFileVersion("0.1.1")]
-[assembly: AssemblyInformationalVersion("0.1.1")]
+[assembly: AssemblyVersion("0.1.2")]
+[assembly: AssemblyFileVersion("0.1.2")]
+[assembly: AssemblyInformationalVersion("0.1.2")]


### PR DESCRIPTION
`RoomsClient.GetAsync` throws `Newtonsoft.Json.JsonSerializationException` if target room has no messages. On this case, HipChat API returns empty string for 'last-active'. But `Room.LastActive` disallow `null` and `JsonConvert.DeserializeObject<Foo>` throws exception.
